### PR TITLE
Fix precise probability quantization.

### DIFF
--- a/ANStoolkit.cpp
+++ b/ANStoolkit.cpp
@@ -87,9 +87,9 @@ struct ANS {
          make_heap(v.begin(),v.end());  
          for( ;used!=L; used+=sgn){
              auto par = v.front(); pop_heap(v.begin(),v.end());v.pop_back();
-             cc[par.second]= -par.first;
+             cc[par.second] -= par.first;
              if((q[par.second]+=sgn)+sgn){
-                v.push_back({- par.first - pow(pL[par.second]-(q[par.second]+sgn),2)*ip[par.second], par.second}); 
+                v.push_back({cc[par.second] - pow(pL[par.second]-(q[par.second]+sgn),2)*ip[par.second], par.second});
                 push_heap (v.begin(),v.end());    
              }
          }


### PR DESCRIPTION
The key to the heap should be the incremental error for adjusting that
probability. cc should track the current quantized error which means
adding the incremental error to the previous error. The newly calculated
error then should then remove the previously accounted for error to get
the next incremental error.

for:
ANS test=init_power(0.11,8);
test.quantize_prec(6);
The quantization rate loss decreases from 0.201408 to 0.199105.
The rate loss for spread_tuned_s() decreases from 0.143563 to 0.139374.
